### PR TITLE
修复导出BUG

### DIFF
--- a/oneforall/oneforall.py
+++ b/oneforall/oneforall.py
@@ -150,6 +150,10 @@ class OneForAll(object):
 
         # 不请求子域直接导出结果
         if not self.req:
+            # 转存解析结果
+            db.clear_table(self.domain)
+            db.save_db(self.domain, self.data, 'resolve')
+        
             # 数据库导出
             self.valid = None
             dbexport.export(self.domain, valid=self.valid,


### PR DESCRIPTION
当设置enable_http_request = False时，导出的结果不包含解析记录。Fix，将解析记录转存到结果表。


