### PR TITLE
建议更改 bing_api.py 搜索方式

### DIFF
--- a/oneforall/modules/search/bing_api.py
+++ b/oneforall/modules/search/bing_api.py
@@ -10,7 +10,7 @@ class BingAPI(Search):
         self.module = 'Search'
         self.source = 'BingAPISearch'
         self.addr = 'https://api.cognitive.microsoft.com/' \
-                    'bingcustomsearch/v7.0/search'
+                    'bing/v7.0/search'
         self.id = api.bing_api_id
         self.key = api.bing_api_key
         self.limit_num = 1000  # 必应同一个搜索关键词限制搜索条数
@@ -31,8 +31,8 @@ class BingAPI(Search):
             self.header = {'Ocp-Apim-Subscription-Key': self.key}
             self.proxy = self.get_proxy(self.source)
             query = 'site:' + domain + filtered_subdomain
-            params = {'q': query, 'customconfig': self.id, 'safesearch': 'Off',
-                      'count': self.per_page_num, 'offset': self.page_num}
+            params = {'q': query, 'safesearch': 'Off', 'count': self.per_page_num,
+                      'offset': self.page_num}
             resp = self.get(self.addr, params)
             if not resp:
                 return


### PR DESCRIPTION
建议改为必应搜索v7，而不是继续使用必应自定义搜索。
因为必应自定义搜索在配置时会要求用户指定搜索的域，并且无法使用通配形式查询。

<img width="968" alt="WX20200415-042716@2x" src="https://user-images.githubusercontent.com/5061489/79270851-70906f80-7ed1-11ea-883a-2faa4a250271.png">
