### PR TITLE
修复 dns 解析开启时会将原本有ip记录的结果遗漏的问题

### DIFF
--- a/common/resolve.py
+++ b/common/resolve.py
@@ -38,6 +38,7 @@ def update_data(data, infos):
     new_data = list()
     for index, items in enumerate(data):
         if items.get('ip'):
+            new_data.append(items)
             continue
         subdomain = items.get('subdomain')
         record = infos.get(subdomain)


### PR DESCRIPTION
修复 issue：   https://github.com/shmilylty/OneForAll/issues/174