### PR TITLE
适应 bing 和 riskiq 模块最新 API 调用方式

### DIFF
--- a/modules/intelligence/riskiq_api.py
+++ b/modules/intelligence/riskiq_api.py
@@ -8,7 +8,7 @@ class RiskIQ(Query):
         self.domain = domain
         self.module = 'Intelligence'
         self.source = 'RiskIQAPIQuery'
-        self.addr = 'https://api.passivetotal.org/v2/enrichment/subdomains'
+        self.addr = 'https://api.riskiq.net/pt/v2/enrichment/subdomains'
         self.user = settings.riskiq_api_username
         self.key = settings.riskiq_api_key
 
@@ -17,6 +17,7 @@ class RiskIQ(Query):
         向接口查询子域并做子域匹配
         """
         self.header = self.get_header()
+        self.header.update({'Accept': 'application/json'})
         self.proxy = self.get_proxy(self.source)
         params = {'query': self.domain}
         resp = self.get(url=self.addr,

--- a/modules/search/bing_api.py
+++ b/modules/search/bing_api.py
@@ -9,7 +9,7 @@ class BingAPI(Search):
         self.domain = domain
         self.module = 'Search'
         self.source = 'BingAPISearch'
-        self.addr = 'https://api.cognitive.microsoft.com/bing/v7.0/search'
+        self.addr = 'https://api.bing.microsoft.com/v7.0/search'
         self.id = settings.bing_api_id
         self.key = settings.bing_api_key
         self.limit_num = 1000  # 必应同一个搜索关键词限制搜索条数


### PR DESCRIPTION
## riskiq
根据 riskiq api文档，api调用链接已发生改变，调用原 api 链接会出现认证失败的情况
https://api.riskiq.net/api/enrichment/#!/default/get_pt_v2_enrichment_subdomains
更改后认证正常，收集子域正常
![image](https://user-images.githubusercontent.com/39155974/141648214-12fc8d9f-4d71-4be3-a727-da4e61b1cd9b.png)

且因 `config/setting.py` 的 `request_default_headers` 默认接受 xml数据接口，导致 `modules/intelligence/riskiq_api.py`  `data = resp.json()` 抛出异常，因此 http 头要增加 `self.header.update({'Accept': 'application/json'})`

## bing
根据 bing api文档，api调用链接已发生改变，调用原 api 链接会出现认证失败的情况
https://docs.microsoft.com/en-us/bing/search-apis/bing-custom-search/reference/endpoints

更改后认证正常，收集子域正常
![image](https://user-images.githubusercontent.com/39155974/141648217-b72168cd-1680-4abc-8099-a2bbb9942f60.png)
