### PR TITLE
fix(massdns):m1 massdns support

### DIFF
--- a/common/utils.py
+++ b/common/utils.py
@@ -605,6 +605,9 @@ def get_massdns_path(massdns_dir):
     system = platform.system().lower()
     machine = platform.machine().lower()
     name = f'massdns_{system}_{machine}'
+    # 表示是mac m1
+    if name == f"massdns_darwin_arm64":
+        name = f"massdns_darwin_x86_64"
     if system == 'windows':
         name = f'massdns.exe'
         if machine == 'amd64':


### PR DESCRIPTION
m1是arm64架构，拼接的路径是massdns_darwin_arm64，实际上用x86_64的massdns就可以了