### PR TITLE
fix github api 400 Bad Request

### DIFF
--- a/modules/search/github_api.py
+++ b/modules/search/github_api.py
@@ -23,6 +23,8 @@ class GithubAPI(Search):
         self.proxy = self.get_proxy(self.source)
         self.header.update(
             {'Accept': 'application/vnd.github.v3.text-match+json'})
+        self.header.update(
+            {'Authorization': 'token ' + self.token})
 
         page = 1
         while True:


### PR DESCRIPTION
Fix github api 400 Bad Request

Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param

![image](https://user-images.githubusercontent.com/44518337/141942887-eb63f427-a3b5-4010-8e8d-e582c1a64386.png)
