### PR TITLE
fix fofa_api.py "Name or service not known"

### DIFF
--- a/modules/search/fofa_api.py
+++ b/modules/search/fofa_api.py
@@ -11,7 +11,7 @@ class FoFa(Search):
         self.domain = domain
         self.module = 'Search'
         self.source = 'FoFaAPISearch'
-        self.addr = 'https://fofa.so/api/v1/search/all'
+        self.addr = 'https://fofa.info/api/v1/search/all'
         self.delay = 1
         self.email = settings.fofa_api_email
         self.key = settings.fofa_api_key


### PR DESCRIPTION
fix fofa_api.py "Name or service not known"
fofa.so域名已不再使用，更换为fofa.info